### PR TITLE
Fix for urls not ending with .git

### DIFF
--- a/git-pull-request
+++ b/git-pull-request
@@ -75,7 +75,7 @@ def main():
     # get repo name from origin
     if(repo == '' or remote != None):
         origin = os.popen('git remote -v').read()
-        m = re.search("^%s.*?github\.com.*?[:/]([^/]+/[^/]+)\.git\s*\(fetch\)$" % remote, origin,re.MULTILINE)
+        m = re.search("^%s.*?github\.com.*?[:/]([^/]+/[^/]+)(\.git)?\s*\(fetch\)$" % remote, origin,re.MULTILINE)
         if(m != None and m.group(1) != ''):
             repo = m.group(1)
 


### PR DESCRIPTION
The regular expression was fixed to make the ".git" part of the url optional.

More details: GitHub allows to clone projects using urls like:

git clone https://github.com/sympy/sympy-live

which don't end with ".git". Previously "git pull-request" failed with:

$ git pull-request
Failed to determine github repository name
The repository is usually automatically detected from your remote origin.
If your origin doesn't point to github, you can specify the repository on
the command line using the -r parameter, by specifying either a remote or
the full repository name (user/repo), or configure it using
git config github.repo <user>/<repository>

After this patch, "git pull-request" works as expected.
