### PR TITLE
Fixes #7: Escapes # in branch names in os.system() call

### DIFF
--- a/git-pull-request
+++ b/git-pull-request
@@ -165,7 +165,7 @@ def fetch(repo, pullreq):
 
     print "pulling from %s (%s)" % (pr['head']['repo']['git_url'], pr['head']['ref']);
 
-    ret = os.system('git pull %s %s' % (pr['head']['repo']['git_url'], pr['head']['ref']));
+    ret = os.system('git pull %s %s' % (pr['head']['repo']['git_url'], pr['head']['ref'].replace('#', '\#')));
 
     print
     print color_text("done. examine changes and merge into master if good",'green');


### PR DESCRIPTION
Works for me, but this os.system call probably needs a more formal tested escaping mechanism :/
